### PR TITLE
Remove Handlebars OPEN_ENDBLOCK without matching OPEN_BLOCK.

### DIFF
--- a/templates/componentName.hbs
+++ b/templates/componentName.hbs
@@ -1,7 +1,6 @@
 {{! Maintainers - Daryl Hedley}}
 <div class="component-inner componentName-inner">
     {{> component this}}
-    {{/if}}
     <div class="component-widget componentName-widget">
     </div>
 </div>


### PR DESCRIPTION
The extra *{{/if}}* is causing compile issues when running the "handlebars:compile" task.